### PR TITLE
Add Quick Reply UI, bot mention handler, and refactor for testability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Google Apps Script (GAS) LINE bot for splitting bills (割り勘). Deployed as a GAS web app whose `doPost` handles LINE Messaging API webhooks. State is persisted in a single Google Sheet.
+
+## Commands
+
+This project uses [`clasp`](https://github.com/google/clasp) to sync with the GAS project (`scriptId` in `.clasp.json`).
+
+- `clasp push` — upload local `.js` / `.json` to GAS
+- `clasp pull` — download GAS source
+- `clasp open` — open the script in the GAS editor
+- `clasp deploy` — create a new web app deployment (after edits, the LINE Webhook URL must point at the latest deployment)
+
+There is no build, lint, or test tooling — runtime is GAS V8 (`appsscript.json`).
+
+## Required Script Properties
+
+`getConfig()` reads these from GAS Script Properties (Project Settings → Script Properties). The bot throws if either is missing:
+
+- `CHANNEL_ACCESS_TOKEN` — LINE Messaging API channel access token
+- `SPREADSHEET_ID` — target spreadsheet ID
+- `SHEET_NAME` — optional, defaults to `シート1`
+
+OAuth scopes are declared in `appsscript.json` (`spreadsheets`, `script.external_request`).
+
+## Architecture
+
+All logic lives in `コード.js` (single file). Entry point is `doPost(e)`, which:
+
+1. Parses the LINE webhook event, extracts `replyToken` and `sourceId` (`groupId || userId`).
+2. Branches on the message text against a fixed command set (order matters — see below).
+3. Each handler returns a reply string; `doPost` posts it back via the LINE reply API.
+4. On error, a row tagged `ERROR` is appended to the sheet and a generic apology is replied.
+
+### Command dispatch order (in `doPost`)
+
+The `if/else if` chain is order-sensitive. In particular:
+
+- `ヘルプ` / `使い方` is checked first.
+- `＃` / `#` (limited split) **must** be checked before `@` / `＠` (normal payment) because `＃`-prefixed messages would otherwise fall through.
+- Messages containing LINE `mention.mentionees` are explicitly ignored (`shouldReply = false`) so `@user` LINE mentions don't collide with the `@payer` command.
+- Anything not matching a command is silently ignored.
+
+### Spreadsheet schema (column → meaning)
+
+Rows are appended by `@` and `＃` handlers; the sheet *is* the database.
+
+| Col | Index | Field |
+|-----|-------|-------|
+| A | 0 | timestamp |
+| B | 1 | sourceId (groupId or userId — scopes records per chat) |
+| C | 2 | senderId (LINE userId of the sender — used by `取消`) |
+| D | 3 | payer name |
+| E | 4 | amount (number) |
+| F | 5 | content / memo |
+| G | 6 | status: `記録済` / `精算済` / `取消済` / `リセット済` |
+| H | 7 | limited-target members, comma-separated (only for `＃`; empty for `@`) |
+
+Status transitions are how the bot avoids deleting rows: `cancelLastRecord`, `resetAllRecords`, and `calculateSettlement` all *update G* rather than removing rows. Queries (`showHistory`, `showMembers`, settlement) filter on `sourceId` + `status === "記録済"`.
+
+### Settlement algorithm (`calculateSettlement`)
+
+Tracks two parallel maps over the participant list parsed from the user's `精算` message:
+
+- `payments[name]` — total each person paid
+- `burdens[name]` — total each person should owe
+
+For each `記録済` row in the same `sourceId`:
+- If H (limited members) is set, burden is split among `participantList ∩ limitedMembers` (the `＃` path; flips `onlyAtCommandsUsed = false`).
+- If H is empty, burden is split equally among all `participantList` (the `@` path).
+- Split uses `floor + remainder` distribution so totals reconcile to the yen.
+
+Balance = `paid - burden`; positives are creditors, negatives are debtors. A two-pointer greedy walk produces the minimum-transaction payoff list. The `1人あたり` summary line is only shown when every contributing row was an `@` record (i.e., uniform split applies).
+
+After computing, all consumed rows are flipped to `精算済`.
+
+### Input normalization
+
+`zenkakuToHankaku` converts full-width digits (`０-９`) before `parseInt`, so amounts typed on a Japanese IME work. Non-digit characters are then stripped from amount strings.
+
+## Notes for editing
+
+- This is a single-file GAS project — adding files means updating `clasp` push order and ensuring GAS picks them up. Prefer extending `コード.js`.
+- The filename `コード.js` is in Japanese; preserve it (it matches the GAS file name on the server).
+- After any edit, `clasp push` then redeploy the web app version that LINE's Webhook URL targets — old deployments keep serving stale code otherwise.

--- a/test.js
+++ b/test.js
@@ -1,0 +1,235 @@
+// ============================================================
+// テスト用ハーネス（本番コードには影響しない）
+// sourceId を "TEST_GROUP_001" にして、本番シート内で論理分離する
+//
+// 実行方法:
+//   1) clasp push
+//   2) GASエディタ or `clasp run __test_runAll` で関数を呼ぶ
+//   3) `clasp logs` で Logger.log の出力を確認
+//
+// ※ テスト後は __test_cleanup() でテスト行を削除する
+// ============================================================
+
+const TEST_SOURCE_ID = 'TEST_GROUP_001';
+const TEST_SENDER_ID = 'TEST_USER_001';
+
+// テスト行を物理削除（本番データには触れない）
+function __test_cleanup() {
+  const config = getConfig();
+  const sheet = SpreadsheetApp.openById(config.SPREADSHEET_ID).getSheetByName(config.SHEET_NAME);
+  const data = sheet.getDataRange().getValues();
+  let deleted = 0;
+  for (let i = data.length - 1; i >= 1; i--) {
+    if (data[i][1] === TEST_SOURCE_ID) {
+      sheet.deleteRow(i + 1);
+      deleted++;
+    }
+  }
+  Logger.log('[cleanup] deleted ' + deleted + ' test rows');
+}
+
+// @コマンド相当: 通常の支払い記録を直接シートに追加
+function __test_seed_at_records() {
+  const config = getConfig();
+  const sheet = SpreadsheetApp.openById(config.SPREADSHEET_ID).getSheetByName(config.SHEET_NAME);
+  sheet.appendRow([new Date(), TEST_SOURCE_ID, TEST_SENDER_ID, 'Alice', 3000, 'lunch', '記録済', '']);
+  sheet.appendRow([new Date(), TEST_SOURCE_ID, TEST_SENDER_ID, 'Bob',   1500, 'snack', '記録済', '']);
+  sheet.appendRow([new Date(), TEST_SOURCE_ID, TEST_SENDER_ID, 'Alice', 4500, 'dinner','記録済', '']);
+  Logger.log('[seed @] 3 rows added');
+}
+
+// ＃コマンド相当: 限定割り勘を登録ロジック経由で追加
+function __test_seed_limited() {
+  const config = getConfig();
+  const text = '#Carol\n6000\nKaraoke\nAlice\nCarol';
+  const reply = registerLimitedPayment(text, TEST_SOURCE_ID, TEST_SENDER_ID, config);
+  Logger.log('[seed #] ' + reply);
+}
+
+function __test_history() {
+  Logger.log('[履歴]\n' + showHistory(TEST_SOURCE_ID));
+}
+
+function __test_members() {
+  Logger.log('[メンバー]\n' + showMembers(TEST_SOURCE_ID));
+}
+
+// 「精算\nAlice\nBob\nCarol」相当
+function __test_settlement_all() {
+  const text = '精算\nAlice\nBob\nCarol';
+  Logger.log('[精算]\n' + calculateSettlement(TEST_SOURCE_ID, text));
+}
+
+// ============================================================
+// handleEvent の自動テスト（純粋関数なので LINE API 不要）
+// ============================================================
+
+// LINE webhook の偽イベントを作るヘルパー
+function __mkEvent(text, opts) {
+  opts = opts || {};
+  const event = {
+    type: "message",
+    replyToken: "DUMMY_TOKEN",
+    source: { groupId: TEST_SOURCE_ID, userId: TEST_SENDER_ID, type: "group" },
+    message: { type: "text", text: text },
+  };
+  if (opts.mention) event.message.mention = opts.mention;
+  return event;
+}
+
+// 簡易アサート（失敗したら throw）
+function __assert(cond, msg) {
+  if (!cond) throw new Error("ASSERT FAILED: " + msg);
+}
+function __assertEq(actual, expected, msg) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error("ASSERT FAILED: " + msg + "\n  expected: " + JSON.stringify(expected) + "\n  actual:   " + JSON.stringify(actual));
+  }
+}
+
+function __test_handleEvent_dispatch() {
+  const config = getConfig();
+  let r;
+  let pass = 0, fail = 0;
+  function check(name, fn) {
+    try { fn(); pass++; Logger.log("  ✅ " + name); }
+    catch (err) { fail++; Logger.log("  ❌ " + name + " — " + err.message); }
+  }
+
+  // 事前: テストデータを少し入れておく（履歴/メンバー系のテスト用）
+  __test_cleanup();
+  __test_seed_at_records();
+
+  Logger.log("--- handleEvent dispatch tests ---");
+
+  check("ヘルプ", function () {
+    r = handleEvent(__mkEvent("ヘルプ"), config);
+    __assert(r.shouldReply === true, "should reply");
+    __assertEq(r.quickReplyLabels, ["履歴", "メンバー"], "labels");
+    __assert(r.replyText.indexOf("【割り勘Botの使い方】") === 0, "help text");
+  });
+
+  check("使い方（ヘルプの別名）", function () {
+    r = handleEvent(__mkEvent("使い方"), config);
+    __assert(r.replyText.indexOf("【割り勘Botの使い方】") === 0, "alias works");
+  });
+
+  check("履歴", function () {
+    r = handleEvent(__mkEvent("履歴"), config);
+    __assertEq(r.quickReplyLabels, ["メンバー", "ヘルプ"], "labels");
+    __assert(r.replyText.indexOf("【未精算の履歴】") === 0, "history text");
+  });
+
+  check("メンバー", function () {
+    r = handleEvent(__mkEvent("メンバー"), config);
+    __assertEq(r.quickReplyLabels, ["履歴", "ヘルプ"], "labels");
+  });
+
+  check("精算（参加者なし＝フォーマットエラー）", function () {
+    r = handleEvent(__mkEvent("精算"), config);
+    __assertEq(r.quickReplyLabels, ["メンバー", "ヘルプ"], "error labels");
+    __assert(r.replyText.indexOf("「精算」コマンドの使い方") === 0, "error text");
+  });
+
+  check("精算（成功パス）", function () {
+    r = handleEvent(__mkEvent("精算\nAlice\nBob"), config);
+    __assert(r.replyText.indexOf("【精算結果】") === 0, "settlement text");
+    __assertEq(r.quickReplyLabels, ["履歴"], "success labels");
+    // 後始末: テスト中に追加した行を「精算済」にされたので、cleanup 用にもう一度 seed
+    __test_cleanup();
+    __test_seed_at_records();
+  });
+
+  check("記録の仕方", function () {
+    r = handleEvent(__mkEvent("記録の仕方"), config);
+    __assertEq(r.quickReplyLabels, ["全員で割る", "一部だけで割る"], "guide labels");
+  });
+
+  check("全員で割る", function () {
+    r = handleEvent(__mkEvent("全員で割る"), config);
+    __assert(r.replyText.indexOf("【全員で割る場合の記録方法】") === 0, "guide text");
+    __assertEq(r.quickReplyLabels, ["履歴", "ヘルプ"], "labels");
+  });
+
+  check("一部だけで割る", function () {
+    r = handleEvent(__mkEvent("一部だけで割る"), config);
+    __assert(r.replyText.indexOf("【一部の人だけで割る場合の記録方法】") === 0, "guide text");
+  });
+
+  check("Bot メンション → 案内を返す", function () {
+    r = handleEvent(__mkEvent("@Bot こんにちは", {
+      mention: { mentionees: [{ index: 0, length: 4, isSelf: true }] }
+    }), config);
+    __assert(r.shouldReply === true, "should reply");
+    __assertEq(r.quickReplyLabels, ["記録の仕方", "履歴", "メンバー", "ヘルプ"], "labels");
+  });
+
+  check("他メンバーへのメンション → 無視", function () {
+    r = handleEvent(__mkEvent("@Alice ねえ", {
+      mention: { mentionees: [{ index: 0, length: 6, isSelf: false }] }
+    }), config);
+    __assert(r.shouldReply === false, "ignored");
+  });
+
+  check("@ 記録（成功）— レコード追加される", function () {
+    r = handleEvent(__mkEvent("@TestPayer\n100\nメモ"), config);
+    __assert(r.replyText.indexOf("【記録しました！】") === 0, "success");
+    __assertEq(r.quickReplyLabels, ["履歴", "取消"], "labels");
+  });
+
+  check("@ 記録 フォーマットエラー（行数不足）", function () {
+    r = handleEvent(__mkEvent("@TestPayer"), config);
+    __assert(r.replyText.indexOf("ごめん") === 0, "error");
+    __assertEq(r.quickReplyLabels, ["ヘルプ"], "labels");
+  });
+
+  check("@ 記録 金額が文字列", function () {
+    r = handleEvent(__mkEvent("@TestPayer\nabc\nメモ"), config);
+    __assert(r.replyText.indexOf("ごめん") === 0, "error");
+  });
+
+  check("@ 全角金額の正規化", function () {
+    r = handleEvent(__mkEvent("@TestPayer\n３０００"), config);
+    __assert(r.replyText.indexOf("3000円") >= 0, "zenkaku → hankaku");
+  });
+
+  check("＃ 限定記録（成功）", function () {
+    r = handleEvent(__mkEvent("＃TestPayer\n500\n限定\nAlice\nBob"), config);
+    __assert(r.replyText.indexOf("【限定記録しました！】") === 0, "success");
+    __assertEq(r.quickReplyLabels, ["履歴", "取消"], "labels");
+  });
+
+  check("＃ 限定記録 対象者なし → エラー", function () {
+    r = handleEvent(__mkEvent("＃TestPayer\n500\n内容"), config);
+    __assert(r.replyText.indexOf("ごめん") === 0, "error");
+    __assertEq(r.quickReplyLabels, ["ヘルプ"], "labels");
+  });
+
+  check("不明なコマンド → 無視", function () {
+    r = handleEvent(__mkEvent("こんにちは"), config);
+    __assert(r.shouldReply === false, "ignored");
+  });
+
+  check("テキスト以外（スタンプ等） → 無視", function () {
+    const stickerEvent = __mkEvent("dummy");
+    stickerEvent.message.type = "sticker";
+    r = handleEvent(stickerEvent, config);
+    __assert(r.shouldReply === false, "ignored");
+  });
+
+  __test_cleanup();
+  Logger.log("--- result: " + pass + " passed / " + fail + " failed ---");
+}
+
+// 一括実行: cleanup → seed → 各クエリ → 精算 → cleanup
+function __test_runAll() {
+  Logger.log('===== test start =====');
+  __test_cleanup();
+  __test_seed_at_records();
+  __test_seed_limited();
+  __test_history();
+  __test_members();
+  __test_settlement_all();
+  __test_cleanup();
+  Logger.log('===== test end =====');
+}

--- a/コード.js
+++ b/コード.js
@@ -18,157 +18,204 @@ function getConfig() {
 // LINEの返信APIのURL
 const REPLY_URL = "https://api.line.me/v2/bot/message/reply";
 
-// LINEからメッセージが来た時に実行される関数
+// Quick Reply ボタンを組み立てる（ラベル文字列＝送信される文字列）
+function buildQuickReply(labels) {
+  if (!labels || labels.length === 0) return null;
+  return {
+    items: labels.map(function (label) {
+      return {
+        type: "action",
+        action: { type: "message", label: label, text: label },
+      };
+    }),
+  };
+}
+
+// LINE 返信（quickReply 任意）
+function sendReply(replyToken, text, quickReplyLabels) {
+  const config = getConfig();
+  const message = { type: "text", text: text };
+  const qr = buildQuickReply(quickReplyLabels);
+  if (qr) message.quickReply = qr;
+  UrlFetchApp.fetch(REPLY_URL, {
+    headers: {
+      "Content-Type": "application/json; charset=UTF-8",
+      Authorization: "Bearer " + config.CHANNEL_ACCESS_TOKEN,
+    },
+    method: "post",
+    payload: JSON.stringify({
+      replyToken: replyToken,
+      messages: [message],
+    }),
+  });
+}
+
+// LINEイベント → 返信内容（{shouldReply, replyText, quickReplyLabels}）を返す純粋関数。
+// LINE API は呼ばないのでテストしやすい。スプレッドシートI/Oは内側の関数に閉じている。
+function handleEvent(event, config) {
+  const empty = { shouldReply: false, replyText: "", quickReplyLabels: [] };
+  if (!event || event.type !== "message" || !event.message || event.message.type !== "text") {
+    return empty;
+  }
+
+  const receivedText = event.message.text.trim();
+  const sourceId = event.source.groupId || event.source.userId;
+  const senderId = event.source.userId;
+
+  if (receivedText === "ヘルプ" || receivedText === "使い方") {
+    return { shouldReply: true, replyText: getHelpMessage(), quickReplyLabels: ["履歴", "メンバー"] };
+  }
+
+  if (receivedText.startsWith("精算") || receivedText.startsWith("清算")) {
+    if (receivedText.includes("\n")) {
+      const text = calculateSettlement(sourceId, receivedText);
+      const labels = text.indexOf("【精算結果】") === 0 ? ["履歴"] : ["ヘルプ"];
+      return { shouldReply: true, replyText: text, quickReplyLabels: labels };
+    }
+    return {
+      shouldReply: true,
+      replyText: "「精算」コマンドの使い方が違うみたい！\n\n精算\n（参加者A）\n（参加者B）\n（参加者C）\n\nのように、改行して「参加者全員」の名前を送ってね。",
+      quickReplyLabels: ["メンバー", "ヘルプ"],
+    };
+  }
+
+  if (receivedText === "リセット") {
+    return { shouldReply: true, replyText: resetAllRecords(sourceId), quickReplyLabels: [] };
+  }
+
+  if (receivedText === "メンバー") {
+    return { shouldReply: true, replyText: showMembers(sourceId), quickReplyLabels: ["履歴", "ヘルプ"] };
+  }
+
+  if (receivedText === "履歴") {
+    return { shouldReply: true, replyText: showHistory(sourceId), quickReplyLabels: ["メンバー", "ヘルプ"] };
+  }
+
+  if (receivedText === "取消" || receivedText === "取り消し") {
+    return { shouldReply: true, replyText: cancelLastRecord(senderId), quickReplyLabels: ["履歴"] };
+  }
+
+  // 限定割り勘 (＃) — 「@」より先に判定する
+  if (receivedText.startsWith("#") || receivedText.startsWith("＃")) {
+    const text = registerLimitedPayment(receivedText, sourceId, senderId, config);
+    const labels = text.indexOf("【限定記録しました！】") === 0 ? ["履歴", "取消"] : ["ヘルプ"];
+    return { shouldReply: true, replyText: text, quickReplyLabels: labels };
+  }
+
+  if (receivedText === "記録の仕方") {
+    return {
+      shouldReply: true,
+      replyText:
+        "誰が割り勘の対象になる？\n\n" +
+        "・全員で割るなら → [全員で割る]\n" +
+        "・一部の人だけで割るなら → [一部だけで割る]",
+      quickReplyLabels: ["全員で割る", "一部だけで割る"],
+    };
+  }
+
+  if (receivedText === "全員で割る") {
+    return {
+      shouldReply: true,
+      replyText:
+        "【全員で割る場合の記録方法】\n\n" +
+        "下のように送ってね（改行して2〜3行）：\n\n" +
+        "@（支払った人）\n（金額）\n（内容）※任意\n\n" +
+        "▼ 例\n@たろう\n3000\nランチ",
+      quickReplyLabels: ["履歴", "ヘルプ"],
+    };
+  }
+
+  if (receivedText === "一部だけで割る") {
+    return {
+      shouldReply: true,
+      replyText:
+        "【一部の人だけで割る場合の記録方法】\n\n" +
+        "下のように送ってね（4行目以降に対象者を全員列挙）：\n\n" +
+        "＃（支払った人）\n（金額）\n（内容）\n（対象者A）\n（対象者B）\n...\n\n" +
+        "▼ 例\n＃たろう\n6000\nカラオケ\nたろう\nはなこ",
+      quickReplyLabels: ["履歴", "ヘルプ"],
+    };
+  }
+
+  if (event.message.mention && event.message.mention.mentionees && event.message.mention.mentionees.length > 0) {
+    const botMentioned = event.message.mention.mentionees.some(function (m) {
+      return m.isSelf === true;
+    });
+    if (botMentioned) {
+      return {
+        shouldReply: true,
+        replyText: "呼んでくれてありがとう！\n何をしたい？\n下のボタンから選んでね。",
+        quickReplyLabels: ["記録の仕方", "履歴", "メンバー", "ヘルプ"],
+      };
+    }
+    return empty;
+  }
+
+  if (receivedText.startsWith("@") || receivedText.startsWith("＠")) {
+    return registerSimplePayment(receivedText, sourceId, senderId, config);
+  }
+
+  return empty;
+}
+
+// @ コマンドの記録処理（handleEventから切り出し、{replyText, quickReplyLabels, shouldReply}を返す）
+function registerSimplePayment(receivedText, sourceId, senderId, config) {
+  const fmtError2or3 = {
+    shouldReply: true,
+    replyText: "ごめん、フォーマットが違うみたい。\n\n@（支払った人）\n（金額）\n（内容は任意）\n\nの2行か3行で送ってね！",
+    quickReplyLabels: ["ヘルプ"],
+  };
+  const fmtErrorAmount = {
+    shouldReply: true,
+    replyText: "ごめん、フォーマットが違うみたい。\n\n@（支払った人）\n（金額）\n（内容は任意）\n\n金額はちゃんと「数字」で送ってね！",
+    quickReplyLabels: ["ヘルプ"],
+  };
+
+  const parts = receivedText.split("\n");
+  parts[0] = parts[0].substring(1).trim();
+  if (parts.length !== 2 && parts.length !== 3) return fmtError2or3;
+
+  const payer = parts[0];
+  const amountString = parts[1].trim();
+  let hankaku = zenkakuToHankaku(amountString).replace(/[^0-9]/g, "");
+  if (!payer || !hankaku || isNaN(hankaku)) return fmtErrorAmount;
+
+  const spreadSheet = SpreadsheetApp.openById(config.SPREADSHEET_ID);
+  const sheet = spreadSheet.getSheetByName(config.SHEET_NAME);
+  const amount = Number(hankaku);
+  const content = parts.length === 3 ? parts[2].trim() : "";
+  sheet.appendRow([new Date(), sourceId, senderId, payer, amount, content, "記録済", ""]);
+
+  let replyText = `【記録しました！】\n支払った人： ${payer}\n金額： ${amount}円`;
+  if (content) replyText += `\n内容： ${content}`;
+  return { shouldReply: true, replyText: replyText, quickReplyLabels: ["履歴", "取消"] };
+}
+
+// LINEからメッセージが来た時に実行される関数（薄いI/Oラッパー）
 function doPost(e) {
   let replyToken = "";
-  let replyText = "";
-  let shouldReply = true;
+  let result = { shouldReply: false, replyText: "", quickReplyLabels: [] };
 
   try {
-    // 設定値を安全に取得
     const config = getConfig();
     const event = JSON.parse(e.postData.contents).events[0];
     replyToken = event.replyToken;
-
-    if (event.type === "message" && event.message.type === "text") {
-      const receivedText = event.message.text.trim();
-      const sourceId = event.source.groupId || event.source.userId;
-
-      // ----------------------------------------------------
-      // メッセージの内容で処理を分岐する
-      // ----------------------------------------------------
-
-      // ★★★ ここからが新しい「ヘルプ」コマンド（一番最初に判定） ★★★
-      if (receivedText === "ヘルプ" || receivedText === "使い方") {
-        replyText = getHelpMessage(); // ヘルプメッセージ専用の関数を呼び出す
-      } else if (
-        receivedText.startsWith("精算") ||
-        receivedText.startsWith("清算")
-      ) {
-        // ←ここは元のコード
-
-        // メッセージに改行が含まれているか（＝参加者リストがあるか）チェック
-        if (receivedText.includes("\n")) {
-          // リストがある場合のみ、計算関数を呼び出す
-          replyText = calculateSettlement(sourceId, receivedText);
-        } else {
-          // 「精算」単体で送られてきた場合
-          replyText =
-            "「精算」コマンドの使い方が違うみたい！\n\n精算\n（参加者A）\n（参加者B）\n（参加者C）\n\nのように、改行して「参加者全員」の名前を送ってね。";
-        }
-        // ★★★ ここからが新しい「リセット」コマンド ★★★
-      } else if (receivedText === "リセット") {
-        const sourceId = event.source.groupId || event.source.userId; // グループIDを取得
-        replyText = resetAllRecords(sourceId); // 新しいリセット関数を呼び出す
-
-        // ★★★ ここからが新しい「メンバー確認」コマンド ★★★
-      } else if (receivedText === "メンバー") {
-        const sourceId = event.source.groupId || event.source.userId; // グループIDを取得
-        replyText = showMembers(sourceId); // 新しいメンバー関数を呼び出す
-
-        // ★★★ ここからが新しい「履歴」コマンド ★★★
-      } else if (receivedText === "履歴") {
-        const sourceId = event.source.groupId || event.source.userId; // グループIDを取得
-        replyText = showHistory(sourceId); // 新しい履歴関数を呼び出す
-
-        // ★★★ ここからが新しい「取消」コマンド ★★★
-      } else if (receivedText === "取消" || receivedText === "取り消し") {
-        const senderId = event.source.userId; // コマンドを送った本人のID
-        replyText = cancelLastRecord(senderId); // 新しい取消関数を呼び出す
-
-      // ★★★ 【NEW!!】限定割り勘コマンド (＃) ★★★
-      // （「@」より先に判定するのがミソ）
-      } else if (
-        receivedText.startsWith("#") || // 半角
-        receivedText.startsWith("＃")  // 全角
-      ) {
-        // ここに「限定割り勘」の記録ロジックを書く！
-        replyText = registerLimitedPayment(receivedText, sourceId, event.source.userId, config);
-
-        // ★★★ ここからが新しい「メンション無視」の処理 ★★★
-      } else if (event.message.mention && event.message.mention.mentionees.length > 0) {
-        // メンション情報が含まれていたら、コマンドとして扱わずに無視する
-        shouldReply = false; 
-
-      } else if (receivedText.startsWith('@') || receivedText.startsWith('＠')) { // ←ここは元のコード
-        const parts = receivedText.split("\n");
-        parts[0] = parts[0].substring(1).trim();
-        if (parts.length === 2 || parts.length === 3) {
-          const payer = parts[0];
-          const amountString = parts[1].trim();
-          let hankakuAmountString = zenkakuToHankaku(amountString);
-          hankakuAmountString = hankakuAmountString.replace(/[^0-9]/g, "");
-          if (payer && hankakuAmountString && !isNaN(hankakuAmountString)) {
-            const spreadSheet = SpreadsheetApp.openById(config.SPREADSHEET_ID);
-            const sheet = spreadSheet.getSheetByName(config.SHEET_NAME);
-            const amount = Number(hankakuAmountString);
-            const content = parts.length === 3 ? parts[2].trim() : "";
-            const status = "記録済";
-            sheet.appendRow([
-              new Date(),
-              sourceId,
-              event.source.userId,
-              payer,
-              amount,
-              content,
-              status,
-              "",
-            ]);
-            replyText = `【記録しました！】\n支払った人： ${payer}\n金額： ${amount}円`;
-            if (content) {
-              replyText += `\n内容： ${content}`;
-            }
-          } else {
-            replyText =
-              "ごめん、フォーマットが違うみたい。\n\n@（支払った人）\n（金額）\n（内容は任意）\n\n金額はちゃんと「数字」で送ってね！";
-          }
-        } else {
-          replyText =
-            "ごめん、フォーマットが違うみたい。\n\n@（支払った人）\n（金額）\n（内容は任意）\n\nの2行か3行で送ってね！";
-        }
-      } else {
-        shouldReply = false; // コマンド以外は無視
-      }
-    } else {
-      shouldReply = false; // テキスト以外は無視
-    }
+    result = handleEvent(event, config);
   } catch (err) {
-    replyText = "ごめん、エラーが発生しちゃったみたい...";
+    result = {
+      shouldReply: true,
+      replyText: "ごめん、エラーが発生しちゃったみたい...",
+      quickReplyLabels: [],
+    };
     try {
       const config = getConfig();
-      const spreadSheet = SpreadsheetApp.openById(config.SPREADSHEET_ID);
-      const sheet = spreadSheet.getSheetByName(config.SHEET_NAME);
-      // セキュリティ向上：詳細な情報はログに残さない
-      sheet.appendRow([
-        new Date(),
-        "ERROR",
-        err.message, // err.toString()ではなくmessageのみ
-        "Request received", // 詳細なリクエスト内容は記録しない
-      ]);
-    } catch (e) {}
+      const sheet = SpreadsheetApp.openById(config.SPREADSHEET_ID).getSheetByName(config.SHEET_NAME);
+      sheet.appendRow([new Date(), "ERROR", err.message, "Request received"]);
+    } catch (e2) {}
   }
 
-  // ----------------------------------------------------
-  // 返信する処理
-  // ----------------------------------------------------
-  if (replyToken && shouldReply) {
-    const config = getConfig();
-    UrlFetchApp.fetch(REPLY_URL, {
-      headers: {
-        "Content-Type": "application/json; charset=UTF-8",
-        Authorization: "Bearer " + config.CHANNEL_ACCESS_TOKEN,
-      },
-      method: "post",
-      payload: JSON.stringify({
-        replyToken: replyToken,
-        messages: [
-          {
-            type: "text",
-            text: replyText,
-          },
-        ],
-      }),
-    });
+  if (replyToken && result.shouldReply) {
+    sendReply(replyToken, result.replyText, result.quickReplyLabels);
   }
 
   return ContentService.createTextOutput(


### PR DESCRIPTION
## Summary

- 各コマンドの返信に Quick Reply ボタンを追加（リセットボタンは除外）
- Bot メンションで使い方ガイド + 2段階のフォーマット案内フローを追加
- doPost から純粋関数 handleEvent を切り出し、LINE API 非依存でテスト可能に
- 自動テスト 17 ケースを test.js に追加
- CLAUDE.md を新規追加（プロジェクト全体のドキュメント）

## Test plan

- [x] GAS エディタで __test_handleEvent_dispatch を実行 → 全件通過
- [x] LINE グループで Quick Reply の動作を確認
- [x] Bot メンションでメニューが返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)